### PR TITLE
Add websocket proxy for devtools communication

### DIFF
--- a/packager/packager.js
+++ b/packager/packager.js
@@ -161,6 +161,7 @@ var server = runServer(options, function() {
 });
 
 webSocketProxy.attachToServer(server, '/debugger-proxy');
+webSocketProxy.attachToServer(server, '/devtools');
 
 function getAppMiddleware(options) {
   var transformerPath = options.transformer;


### PR DESCRIPTION
I thought this was already in here, but then it wasn't. It's connected to by RN [here](https://github.com/facebook/react-native/blob/master/Libraries/Devtools/setupDevtools.js#L17).
